### PR TITLE
Recover windows installer cmake file.

### DIFF
--- a/src/installer/CMakeLists.txt
+++ b/src/installer/CMakeLists.txt
@@ -90,4 +90,18 @@ install(FILES "${PROJECT_ROOT}/THIRD-PARTY" DESTINATION doc COMPONENT "Docs")
 # Install resource files
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/Resources/opensearch_sql_odbc.tdc" DESTINATION resources COMPONENT "Resources")
 
+if(WIN32)
+    set(AWS_SDK_BIN_DIR "${PROJECT_ROOT}/src/vcpkg_installed/x${BITNESS}-windows/bin")
+    install(DIRECTORY ${AWS_SDK_BIN_DIR} DESTINATION . COMPONENT "Driver" FILES_MATCHING PATTERN "*.dll")
+
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        # We actually never build the installer for Debug
+        install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug/libcurl-d.dll" DESTINATION bin COMPONENT "Driver")
+        install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Debug/zlibd1.dll" DESTINATION bin COMPONENT "Driver")
+    else() # release
+        install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/libcurl.dll" DESTINATION bin COMPONENT "Driver")
+        install(FILES "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/zlib1.dll" DESTINATION bin COMPONENT "Driver")
+    endif()
+endif()
+
 include(CPack)


### PR DESCRIPTION
### Description
Partially revert changes from #27.
New installer content:
![image](https://github.com/opensearch-project/sql-odbc/assets/88679692/4b764c1f-978f-42eb-9bb7-e84572329925)
Tested on Windows 32/64 bit and Mac.
 
### Issues Resolved
Fixes #43 
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).