### PR TITLE
Update `SHOW TABLES` query.

### DIFF
--- a/src/sqlodbc/opensearch_communication.cpp
+++ b/src/sqlodbc/opensearch_communication.cpp
@@ -481,7 +481,7 @@ bool OpenSearchCommunication::IsSQLPluginEnabled(std::shared_ptr< ErrorDetails >
  */
 bool OpenSearchCommunication::CheckSQLPluginAvailability() {
     LogMsg(OPENSEARCH_ALL, "Checking for SQL plugin status.");
-    std::string test_query = "SHOW TABLES LIKE %";
+    std::string test_query = "SHOW TABLES LIKE '%'";
     try {
         std::shared_ptr< Aws::Http::HttpResponse > response =
             IssueRequest(sql_endpoint,

--- a/src/sqlodbc/opensearch_info.cpp
+++ b/src/sqlodbc/opensearch_info.cpp
@@ -652,12 +652,13 @@ void GenerateColumnQuery(std::string &query, const std::string &table_name,
                          const std::string &column_name, const bool table_valid,
                          const bool column_valid, const UWORD flag) {
     bool search_pattern = (~flag & PODBC_NOT_SEARCH_PATTERN);
-    query = "DESCRIBE TABLES LIKE ";
+    query = "DESCRIBE TABLES LIKE '";
     query += table_valid
                  ? (search_pattern ? table_name : "^" + table_name + "$")
                  : "%";
+    query += '\'';
     if (column_valid)
-        query += " COLUMNS LIKE " + column_name;
+        query += " COLUMNS LIKE '" + column_name + '\'';
 }
 
 // In case of unique_ptr's, using push_back (over emplace_back) is preferred in

--- a/src/sqlodbc/opensearch_info.cpp
+++ b/src/sqlodbc/opensearch_info.cpp
@@ -423,9 +423,9 @@ void GenerateTableQuery(std::string &tables_query, const UWORD flag,
     if (table_valid && (table_name_value != "")
         && (result_type == TableResultSet::All))
         tables_query +=
-            search_pattern ? table_name_value : "^" + table_name_value + "$";
+            search_pattern ? table_name_value : "'^" + table_name_value + "$'";
     else
-        tables_query += "%";
+        tables_query += "'%'";
 }
 
 // In case of unique_ptr's, using push_back (over emplace_back) is preferred in


### PR DESCRIPTION
### Description
`SHOW TABLES LIKE %` query was used to verify the connection. As of https://github.com/opensearch-project/sql/pull/1181, query syntax changed in V2. This query was falling back to V1 SQL plugin engine, which would be deprecated once upon a time. Updating this query in ODBC driver ensures that SQL plugin would properly respond to it.

### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).