### PR TITLE
Update `.gitignore`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ CTestTestfile.cmake
 /src/PowerBIConnector/bin/Debug/
 /src/PowerBIConnector/obj/
 /src/PowerBIConnector/.vs/
+src/vcpkg_installed/


### PR DESCRIPTION
### Description
New build (#27) downloads `vcpkg` dependencies into `src/vcpkg_installed/`, so I added this directory to `.gitignore` to avoid committing them by mistake.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).