### PR TITLE
Update maintainer list.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @MaxKsyunz @Yury-Fridlyand @anirudha
+*   @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @MaxKsyunz @Yury-Fridlyand @anirudha @forestmvey @acarbonetto @GumpacG

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,9 +19,12 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Vamsi Manohar     | [vamsi-amazon](https://github.com/vamsi-amazon)     | Amazon      |
 | Peng Huo          | [penghuo](https://github.com/penghuo)               | Amazon      |
 | Sean Kao          | [seankao-az](https://github.com/seankao-az)         | Amazon      |
-| Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)           | BitQuill    |
-| Yury Fridlyand    | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | BitQuill    |
 | Anirudha Jadhav   | [anirudha](https://github.com/anirudha)             | Amazon      |
+| Max Ksyunz        | [MaxKsyunz](https://github.com/MaxKsyunz)           | Improving   |
+| Yury Fridlyand    | [Yury-Fridlyand](https://github.com/Yury-Fridlyand) | Improving   |
+| Andrew Carbonetto | [acarbonetto](https://github.com/acarbonetto)       | Improving   |
+| Forest Vey        | [forestmvey](https://github.com/forestmvey)         | Improving   |
+| Guian Gumpac      | [GumpacG](https://github.com/GumpacG)               | Improving   |
 
 ## Emeritus Maintainers
 


### PR DESCRIPTION
### Description
Update maintainers list according to nominating voting happened recently:
* @Yury-Fridlyand +1
* @joshuali925 +1
* @rupal-bq +1
* @anirudha +1

Please, see [becoming a maintainer](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer) doc section.

New maintainers promoted:
* @forestmvey
* @GumpacG
* @acarbonetto

These people are crucial SQL plugin developers, maintainers and codeowners on [SQL plugin repository](https://github.com/opensearch-project/sql). See https://github.com/opensearch-project/sql/pull/1609 for reference.
Voting records are available here: [Maintainer nomination.pdf](https://github.com/opensearch-project/sql-jdbc/files/11699597/Maintainer.nomination.pdf)


Welcome!

Once PR approved I'll ask admin to update actual permissions.

Note: Bit Quill was recently acquired by Improving (links: [one](https://www.bitquill.com/), [two](https://improving.com/thoughts/improving-acquires-bit-quill/)).

### Issues Resolved
Update maintainers list.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).