### PR TITLE
Onboard 1-click release process

### DIFF
--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -1,4 +1,4 @@
-name: Release Drafter
+name: Release Notes Drafter
 
 on:
   push:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,7 +14,7 @@ jobs:
       - id: get_data
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
-          echo "version=$(cat version.properties)" >> $GITHUB_OUTPUT
+          echo "version=$(grep DRIVER_PACKAGE_VERSION src/CMakeLists.txt | grep -o -P '\d+\.\d+\.\d+\.\d+')" >> $GITHUB_OUTPUT
       - uses: trstringer/manual-approval@v1
         with:
           secret: ${{ github.TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,14 +17,13 @@ jobs:
           workflow: sql-odbc-main.yml
           commit: ${{github.sha}}
           workflow_conclusion: success
-          skip_unpack: true
+
+      - name: Pack artifacts
+        run: tar -cvf artifacts.tar.gz *-installer
 
       - name: Draft a release
         uses: softprops/action-gh-release@v1
         with:
           draft: true
           generate_release_notes: true
-          files: |
-            mac64-installer.zip
-            windows32-installer.zip
-            windows64-installer.zip
+          files: artifacts.tar.gz

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,30 @@
+name: Release drafter
+
+# Push events to every tag not containing "/"
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  draft-a-release:
+    name: Draft a release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: dawidd6/action-download-artifact@v2.27.0
+        with:
+          workflow: sql-odbc-main.yml
+          branch: main
+          workflow_conclusion: success
+          skip_unpack: true
+
+      - name: Draft a release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            mac64-build.zip
+            windows32-installer.zip
+            windows64-installer.zip

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ jobs:
         uses: dawidd6/action-download-artifact@v2.27.0
         with:
           workflow: sql-odbc-main.yml
-          branch: main
+          commit: ${{github.sha}}
           workflow_conclusion: success
           skip_unpack: true
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,19 @@ jobs:
     name: Draft a release
     runs-on: ubuntu-latest
     steps:
+      - id: get_data
+        run: |
+          echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
+          echo "version=$(cat version.properties)" >> $GITHUB_OUTPUT
+      - uses: trstringer/manual-approval@v1
+        with:
+          secret: ${{ github.TOKEN }}
+          approvers: ${{ steps.get_data.outputs.approvers }}
+          minimum-approvals: 2
+          issue-title: 'Release ODBC driver version ${{ steps.get_data.outputs.version }}'
+          issue-body: "Please approve or deny the release of ODBC Driver **TAG**: ${{ github.ref_name }}  **COMMIT**: ${{ github.sha }} **VERSION** : ${{ steps.get_data.outputs.version }} "
+          exclude-workflow-initiator-as-approver: true
+
       - name: Download artifacts
         uses: dawidd6/action-download-artifact@v2.27.0
         with:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,8 +18,11 @@ jobs:
           commit: ${{github.sha}}
           workflow_conclusion: success
 
-      - name: Pack artifacts
-        run: tar -cvf artifacts.tar.gz *-installer
+      - name: Rename and pack artifacts
+        run: |
+          # replace spaces by dashes in file names
+          for i in *-installer/*; do mv "$i" "${i//\ /-}"; done
+          tar -cvf artifacts.tar.gz *-installer
 
       - name: Draft a release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -25,6 +25,6 @@ jobs:
           draft: true
           generate_release_notes: true
           files: |
-            mac64-build.zip
+            mac64-installer.zip
             windows32-installer.zip
             windows64-installer.zip

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,40 @@
+- [Overview](#overview)
+- [Branching](#branching)
+  - [Release Branching](#release-branching)
+  - [Feature Branches](#feature-branches)
+- [Release Labels](#release-labels)
+- [Releasing](#releasing)
+
+## Overview
+
+This document explains the release strategy for artifacts in this organization.
+
+## Branching
+
+### Release Branching
+
+Given the current major release of 1.0, projects in this organization maintain the following active branches.
+
+* **main**: The next _major_ release. This is the branch where all merges take place and code moves fast.
+* **1.x**: The next _minor_ release. Once a change is merged into `main`, decide whether to backport it to `1.x`.
+* **1.0**: The _current_ release. In between minor releases, only hotfixes (e.g. security) are backported to `1.0`.
+
+Label PRs with the next major version label (e.g. `v2.0.0.0`) and merge changes into `main`. Label PRs that you believe need to be backported as `backport 1.x` and `backport 1.0`. Backport PRs by checking out the versioned branch, cherry-pick changes and open a PR against each target backport branch.
+
+### Feature Branches
+
+Do not create branches in the upstream repo, use your fork, for the exception of long lasting feature branches that require active collaboration from multiple developers. Name feature branches `feature/<thing>`. Once the work is merged to `main`, please make sure to delete the feature branch.
+
+## Release Labels
+
+Repositories create consistent release labels, such as `v1.0.0`, `v1.1.0` and `v2.0.0`, as well as `patch` and `backport`. Use release labels to target an issue or a PR for a given release.
+
+## Releasing
+
+The release process is standard across repositories in this org and is run by a release manager volunteering from amongst [maintainers](MAINTAINERS.md).
+
+1. Create a tag, e.g. 1.0.0.0, and push it to this GitHub repository.
+2. The [release-drafter.yml](.github/workflows/release-drafter.yml) will be automatically kicked off and a draft release will be created.
+3. This draft release triggers the [jenkins release workflow](https://build.ci.opensearch.org/job/sql-odbc-release) as a result of which the driver is released and published on artifacts (https://artifacts.opensearch.org/opensearch-clients/odbc/). Please note, that the release workflow is triggered only if created release is in draft state. Manual update on the [download page](https://opensearch.org/downloads.html#drivers) is required after that, see [website repo](https://github.com/opensearch-project/project-website/tree/main/_artifacts/opensearch-drivers).
+4. Once the above release workflow is successful, the drafted release on GitHub is published automatically.
+5. Increment `DRIVER_PACKAGE_VERSION` in [src/CMakeLists.txt](src/CMakeLists.txt) to the next iteration, e.g. 1.0.0.1 See [example](https://github.com/opensearch-project/sql-odbc/pull/47).

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,0 +1,16 @@
+lib = library(identifier: 'jenkins@1.5.3', retriever: modernSCM([
+    $class: 'GitSCMSource',
+    remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
+]))
+
+standardReleasePipelineWithGenericTrigger(
+    tokenIdCredential: 'jenkins-sql-odbc-generic-webhook-token',
+    causeString: 'A tag was cut on opensearch-project/sql-odbc repository causing this workflow to run',
+    downloadReleaseAsset: true,
+    publishRelease: true) {
+        publishToMaven(
+            signingArtifactsPath: "$WORKSPACE/repository/",
+            mavenArtifactsPath: "$WORKSPACE/repository/",
+            autoPublish: true
+        )
+    }

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -10,23 +10,23 @@ standardReleasePipelineWithGenericTrigger(
     publishRelease: true) {
                         publishToArtifactsProdBucket(
                             assumedRoleName: 'sql-odbc-upload-role',
-                            source: 'opensearch-sql-odbc-driver-32-bit-1.5.0.0-Windows.msi',
+                            source: 'windows32-installer/OpenSearch-SQL-ODBC-Driver-32-bit-1.5.0.0-Windows.msi',
                             destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-32-bit-1.5.0.0-Windows.msi',
                             signingPlatform: 'windows',
                             sigType: 'null',
                             sigOverwrite: true
                         )
-                     publishToArtifactsProdBucket(
+                        publishToArtifactsProdBucket(
                             assumedRoleName: 'sql-odbc-upload-role',
-                            source: 'opensearch-sql-odbc-driver-64-bit-1.5.0.0-Windows.msi',
+                            source: 'windows64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Windows.msi',
                             destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Windows.msi',
                             signingPlatform: 'windows',
                             sigType: 'null',
                             sigOverwrite: true
                         )
-                      publishToArtifactsProdBucket(
+                        publishToArtifactsProdBucket(
                             assumedRoleName: 'sql-odbc-upload-role',
-                            source: 'opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg,
+                            source: 'mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg',
                             destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg',
                             signingPlatform: 'macos',
                             sigType: 'null',

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@1.5.3', retriever: modernSCM([
+lib = library(identifier: 'jenkins@4.2.2', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -8,9 +8,28 @@ standardReleasePipelineWithGenericTrigger(
     causeString: 'A tag was cut on opensearch-project/sql-odbc repository causing this workflow to run',
     downloadReleaseAsset: true,
     publishRelease: true) {
-        publishToMaven(
-            signingArtifactsPath: "$WORKSPACE/repository/",
-            mavenArtifactsPath: "$WORKSPACE/repository/",
-            autoPublish: true
-        )
+                        publishToArtifactsProdBucket(
+                            assumedRoleName: 'sql-odbc-upload-role',
+                            source: 'opensearch-sql-odbc-driver-32-bit-1.5.0.0-Windows.msi',
+                            destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-32-bit-1.5.0.0-Windows.msi',
+                            signingPlatform: 'windows',
+                            sigType: 'null',
+                            sigOverwrite: true
+                        )
+                     publishToArtifactsProdBucket(
+                            assumedRoleName: 'sql-odbc-upload-role',
+                            source: 'opensearch-sql-odbc-driver-64-bit-1.5.0.0-Windows.msi',
+                            destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Windows.msi',
+                            signingPlatform: 'windows',
+                            sigType: 'null',
+                            sigOverwrite: true
+                        )
+                      publishToArtifactsProdBucket(
+                            assumedRoleName: 'sql-odbc-upload-role',
+                            source: 'opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg,
+                            destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg',
+                            signingPlatform: 'macos',
+                            sigType: 'null',
+                            sigOverwrite: true
+                        )
     }

--- a/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
+++ b/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
@@ -41,3 +41,5 @@
 * Bump version and update vendor. ([#47](https://github.com/opensearch-project/sql-odbc/pull/47))
 * Add release notes for version 1.5. ([#49](https://github.com/opensearch-project/sql-odbc/pull/49))
 * Update `.gitignore`. ([#50](https://github.com/opensearch-project/sql-odbc/pull/50))
+* Update maintainer list. ([#51](https://github.com/opensearch-project/sql-odbc/pull/51))
+* Onboard 1 click release process. ([#52](https://github.com/opensearch-project/sql-odbc/pull/52)


### PR DESCRIPTION
### Description
Following @gaiksaya request from https://github.com/opensearch-project/opensearch-build/issues/3633.
As a sample I used [JDBC driver](https://github.com/opensearch-project/sql-jdbc) files and PR 48: https://github.com/opensearch-project/sql-jdbc/pull/48.

See new workflow run: https://github.com/Bit-Quill/sql-odbc/actions/runs/5325195930/jobs/9646261731
And draft release created: https://github.com/Bit-Quill/sql-odbc/releases
Each zip contains an installer which should be signed by Jenkins and published on artifacts.

![image](https://github.com/opensearch-project/sql-odbc/assets/88679692/b3b76de6-ab48-48b8-aed1-e9b07af48d9d)
 
### Issues Resolved
Make release process ~great again~ automatic.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).