### PR TITLE
Always save vcpkg in cache.

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -55,7 +55,6 @@ jobs:
         ./build_mac_release64.sh
 
     - name: Save vcpkg cache
-      if: steps.cache-restore.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
         path: src/vcpkg_installed

--- a/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
+++ b/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
@@ -43,3 +43,4 @@
 * Update `.gitignore`. ([#50](https://github.com/opensearch-project/sql-odbc/pull/50))
 * Update maintainer list. ([#51](https://github.com/opensearch-project/sql-odbc/pull/51))
 * Onboard 1 click release process. ([#52](https://github.com/opensearch-project/sql-odbc/pull/52)
+* Optimize cache usage in CI. ([#53](https://github.com/opensearch-project/sql-odbc/pull/53))


### PR DESCRIPTION
### Description
Initially cache was introduced in #45. Unfortunately, vcpkg sometimes ignores restored cache and rebuilds everything: https://github.com/opensearch-project/sql-odbc/actions/runs/5351645007/jobs/9705946814. Probably, restored data expires for `vcpkg`.
This fix make cache always saved, so it refreshes it if something was changed.
 
### Issues Resolved
Speed up CI.
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).