### PR TITLE
Fix jenkins lib version to accommodate mac signing

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,4 +1,4 @@
-lib = library(identifier: 'jenkins@4.2.2', retriever: modernSCM([
+lib = library(identifier: 'jenkins@4.4.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
@@ -28,7 +28,7 @@ standardReleasePipelineWithGenericTrigger(
                             assumedRoleName: 'sql-odbc-upload-role',
                             source: 'mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg',
                             destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg',
-                            signingPlatform: 'macos',
+                            signingPlatform: 'mac',
                             sigType: 'null',
                             sigOverwrite: true
                         )

--- a/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
+++ b/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
@@ -13,6 +13,7 @@
 
 * ODBC SSL Compliance Fix ([#653](https://github.com/opensearch-project/sql/pull/653))
 * Reverted UseSSL flag to false and removed invalid test case ([#671](https://github.com/opensearch-project/sql/pull/671))
+* Fix jenkins lib version to accommodate mac signing ([#54](https://github.com/opensearch-project/sql-odbc/pull/54))
 
 ### Documentation
 


### PR DESCRIPTION
### Description
Fix jenkins lib version to accommodate mac signing
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).