### PR TITLE
Refactor jenkins pipeline to support multi-platform artifacts

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -89,15 +89,15 @@ pipeline {
                                 sh 'ls -l'
                                 publishToArtifactsProdBucket(
                                     assumedRoleName: 'sql-odbc-upload-role',
-                                    source: "${WORKSPACE}/windows32-installer/OpenSearch-SQL-ODBC-Driver-32-bit-1.5.0.0-Windows.msi",
-                                    destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-32-bit-1.5.0.0-Windows.msi',
+                                    source: "${WORKSPACE}/windows32-installer/OpenSearch-SQL-ODBC-Driver-32-bit-${tag}-Windows.msi",
+                                    destination: "opensearch-clients/odbc/opensearch-sql-odbc-driver-32-bit-${tag}-Windows.msi",
                                     signingPlatform: 'windows',
                                     sigOverwrite: true
                                 )
                                 publishToArtifactsProdBucket(
                                     assumedRoleName: 'sql-odbc-upload-role',
-                                    source: "${WORKSPACE}/windows64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Windows.msi",
-                                    destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Windows.msi',
+                                    source: "${WORKSPACE}/windows64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-${tag}-Windows.msi",
+                                    destination: "opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-${tag}-Windows.msi",
                                     signingPlatform: 'windows',
                                     sigOverwrite: true
                                 )
@@ -115,8 +115,8 @@ pipeline {
                             unstash 'odbc-release-artifacts'
                             publishToArtifactsProdBucket(
                                 assumedRoleName: 'sql-odbc-upload-role',
-                                source: "${WORKSPACE}/mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg",
-                                destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg',
+                                source: "${WORKSPACE}/mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-${tag}-Darwin.pkg",
+                                destination: "opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-${tag}-Darwin.pkg",
                                 signingPlatform: 'mac',
                                 sigOverwrite: true
                             )

--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -1,35 +1,156 @@
+/*
+* Copyright OpenSearch Contributors
+* SPDX-License-Identifier: Apache-2.0
+*
+* The OpenSearch Contributors require contributions made to
+* this file be licensed under the Apache-2.0 license or a
+* compatible open source license.
+*/
 lib = library(identifier: 'jenkins@4.4.0', retriever: modernSCM([
     $class: 'GitSCMSource',
     remote: 'https://github.com/opensearch-project/opensearch-build-libraries.git',
 ]))
 
-standardReleasePipelineWithGenericTrigger(
-    tokenIdCredential: 'jenkins-sql-odbc-generic-webhook-token',
-    causeString: 'A tag was cut on opensearch-project/sql-odbc repository causing this workflow to run',
-    downloadReleaseAsset: true,
-    publishRelease: true) {
-                        publishToArtifactsProdBucket(
-                            assumedRoleName: 'sql-odbc-upload-role',
-                            source: 'windows32-installer/OpenSearch-SQL-ODBC-Driver-32-bit-1.5.0.0-Windows.msi',
-                            destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-32-bit-1.5.0.0-Windows.msi',
-                            signingPlatform: 'windows',
-                            sigType: 'null',
-                            sigOverwrite: true
-                        )
-                        publishToArtifactsProdBucket(
-                            assumedRoleName: 'sql-odbc-upload-role',
-                            source: 'windows64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Windows.msi',
-                            destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Windows.msi',
-                            signingPlatform: 'windows',
-                            sigType: 'null',
-                            sigOverwrite: true
-                        )
-                        publishToArtifactsProdBucket(
-                            assumedRoleName: 'sql-odbc-upload-role',
-                            source: 'mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg',
-                            destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg',
-                            signingPlatform: 'mac',
-                            sigType: 'null',
-                            sigOverwrite: true
-                        )
+pipeline {
+    agent none
+    options {
+        timeout(time: 1, unit: 'HOURS')
     }
+    triggers {
+        GenericTrigger(
+            genericVariables: [
+                [key: 'ref', value: ('$.release.tag_name')],
+                [key: 'repository', value: '$.repository.html_url'],
+                [key: 'action', value: '$.action'],
+                [key: 'isDraft', value: '$.release.draft'],
+                [key: 'release_url', value: '$.release.url'],
+                [key: 'assets_url', value: '$.release.assets_url']
+            ],
+            tokenCredentialId: 'jenkins-sql-odbc-generic-webhook-token',
+            causeString: 'A tag was cut on opensearch-project/sql-odbc repository causing this workflow to run',
+            printContributedVariables: false,
+            printPostContent: false,
+            regexpFilterText: ('$isDraft $action'),
+            regexpFilterExpression: ('^true created$')
+        )
+    }
+    environment {
+        tag = "$ref"
+        repository = "$repository"
+    }
+    stages {
+        stage('Download artifacts') {
+            agent {
+                docker {
+                    label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+                    image 'opensearchstaging/ci-runner:release-centos7-clients-v1'
+                    args '-e JAVA_HOME=/opt/java/openjdk-11'
+                    alwaysPull true
+                }
+            }
+            steps {
+                script {
+                    if ("$assets_url" != '') {
+                        withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+                            String assets = sh(
+                                script: "curl -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assets_url}",
+                                returnStdout: true
+                            )
+                            String assetUrl = null
+                            def parsedJson = readJSON text: assets
+                            def assetName = 'artifacts.tar.gz'
+                            parsedJson.each { item ->
+                                if (item.name == assetName) {
+                                    assetUrl = item.url
+                                }
+                            }
+                            echo "Downloading artifacts from $assetUrl"
+                            sh "curl -J -L -H 'Accept: application/octet-stream' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${assetUrl} -o artifacts.tar.gz && tar -xvf artifacts.tar.gz"
+                            stash includes: '**', name: 'odbc-release-artifacts'
+                        }
+                    }
+                }
+            }
+        }
+        stage('Release artifacts') {
+            parallel {
+                stage('Release Windows artifacts') {
+                    agent {
+                        docker {
+                            label 'Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host'
+                            image 'opensearchstaging/ci-runner:release-centos7-clients-v1'
+                            args '-e JAVA_HOME=/opt/java/openjdk-11'
+                            alwaysPull true
+                        }
+                    }
+                    steps {
+                        script {
+                                unstash 'odbc-release-artifacts'
+                                sh 'ls -l'
+                                publishToArtifactsProdBucket(
+                                    assumedRoleName: 'sql-odbc-upload-role',
+                                    source: "${WORKSPACE}/windows32-installer/OpenSearch-SQL-ODBC-Driver-32-bit-1.5.0.0-Windows.msi",
+                                    destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-32-bit-1.5.0.0-Windows.msi',
+                                    signingPlatform: 'windows',
+                                    sigOverwrite: true
+                                )
+                                publishToArtifactsProdBucket(
+                                    assumedRoleName: 'sql-odbc-upload-role',
+                                    source: "${WORKSPACE}/windows64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Windows.msi",
+                                    destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Windows.msi',
+                                    signingPlatform: 'windows',
+                                    sigOverwrite: true
+                                )
+                        }
+                    }
+                }
+                stage('Release Mac Artifacts') {
+                    agent {
+                        node {
+                            label 'Jenkins-Agent-MacOS12-X64-Mac1Metal-Multi-Host'
+                        }
+                    }
+                    steps {
+                        script {
+                            unstash 'odbc-release-artifacts'
+                            publishToArtifactsProdBucket(
+                                assumedRoleName: 'sql-odbc-upload-role',
+                                source: "${WORKSPACE}/mac64-installer/OpenSearch-SQL-ODBC-Driver-64-bit-1.5.0.0-Darwin.pkg",
+                                destination: 'opensearch-clients/odbc/opensearch-sql-odbc-driver-64-bit-1.5.0.0-Darwin.pkg',
+                                signingPlatform: 'mac',
+                                sigOverwrite: true
+                            )
+                        }
+                    }
+                    post {
+                        always {
+                            script {
+                                postCleanup()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    post {
+        success {
+            node('Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host') {
+                script {
+                    if (release_url != null) {
+                        withCredentials([usernamePassword(credentialsId: 'jenkins-github-bot-token', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+                            sh "curl -X PATCH -H 'Accept: application/vnd.github+json' -H 'Authorization: Bearer ${GITHUB_TOKEN}' ${release_url} -d '{\"tag_name\":\"${tag}\",\"draft\":false,\"prerelease\":false}'"
+                        }
+                    }
+                }
+            }
+        }
+        always {
+            node('Jenkins-Agent-AL2-X64-C54xlarge-Docker-Host') {
+                script {
+                    postCleanup()
+                }
+            }
+        }
+    }
+}

--- a/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
+++ b/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
@@ -13,7 +13,7 @@
 
 * ODBC SSL Compliance Fix ([#653](https://github.com/opensearch-project/sql/pull/653))
 * Reverted UseSSL flag to false and removed invalid test case ([#671](https://github.com/opensearch-project/sql/pull/671))
-* Fix jenkins lib version to accommodate mac signing ([#54](https://github.com/opensearch-project/sql-odbc/pull/54))
+* Fix and refactor jenkins lib version to accommodate multi-platform artifacts ([#54](https://github.com/opensearch-project/sql-odbc/pull/54) [#55](https://github.com/opensearch-project/sql-odbc/pull/55))
 
 ### Documentation
 


### PR DESCRIPTION
### Description
Signing verification works well on linux even for windows artifacts, however for mac artifacts that uses [pkgutil](https://github.com/opensearch-project/opensearch-build/blob/main/src/sign_workflow/signer_mac.py#L54), it is necessary to use underlying jenkins agent as macos (Darwin).
The all in one standard release pipeline used one agent overall and had some defaults such as dockerAgents, etc which is not used by mac agent yet!
Since it does not fit the standard release pipeline, creating its own jenkins pipeline.
 
### Issues Resolved
related https://github.com/opensearch-project/opensearch-build/issues/3633
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).