### PR TITLE
Fix release drafter CI workflow.

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,6 +11,7 @@ jobs:
     name: Draft a release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - id: get_data
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT

--- a/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
+++ b/release-notes/sql-odbc.OpenSearch.release-notes-1.5.0.0.md
@@ -46,3 +46,4 @@
 * Update maintainer list. ([#51](https://github.com/opensearch-project/sql-odbc/pull/51))
 * Onboard 1 click release process. ([#52](https://github.com/opensearch-project/sql-odbc/pull/52)
 * Optimize cache usage in CI. ([#53](https://github.com/opensearch-project/sql-odbc/pull/53))
+* Fix release drafter CI workflow. ([#57](https://github.com/opensearch-project/sql-odbc/pull/57))


### PR DESCRIPTION
### Description
See failed workflow https://github.com/opensearch-project/sql-odbc/actions/runs/5457662911/jobs/9931920251. Actually failed on the third step.
 
### Issues Resolved
Typo fix introduced in #52
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).