### PR TITLE
Override default release docker image

### DIFF
--- a/jenkins/release.jenkinsFile
+++ b/jenkins/release.jenkinsFile
@@ -4,6 +4,7 @@ lib = library(identifier: 'jenkins@4.4.0', retriever: modernSCM([
 ]))
 
 standardReleasePipelineWithGenericTrigger(
+    overrideDockerImage: 'opensearchstaging/ci-runner:release-centos7-clients-v2.3',
     tokenIdCredential: 'jenkins-sql-odbc-generic-webhook-token',
     causeString: 'A tag was cut on opensearch-project/sql-odbc repository causing this workflow to run',
     downloadReleaseAsset: true,


### PR DESCRIPTION
### Description
Default image is v1 which does not contain osslsigncode package to verify windows signatures.
See failure: https://build.ci.opensearch.org/view/Release/job/sql-odbc-release/5/console
 
### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/3633
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).