### PR TITLE
Fix build-mac job

### DIFF
--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -19,7 +19,7 @@ env:
 # Keeping them for the brighten future when we can re-activate them
 jobs:    
   build-mac:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v3
     - name: Run cppcheck

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ endif()
 if(MSVC)
   add_compile_options(/W4 /WX)
 else()
-  add_compile_options(-Wall -Wextra -pedantic -Werror)
+  add_compile_options(-Wall -Wextra -pedantic -Werror -Wno-strict-prototypes -Wno-deprecated-declarations)
 endif()
 
 if(NOT WIN32)

--- a/src/PerformanceTests/PTODBCResults/performance_odbc_results.cpp
+++ b/src/PerformanceTests/PTODBCResults/performance_odbc_results.cpp
@@ -118,7 +118,6 @@ TEST_F(TestPerformance, Time_Execute) {
 
 TEST_F(TestPerformance, Time_BindColumn_FetchSingleRow) {
     SQLSMALLINT total_columns = 0;
-    int row_count = 0;
 
     std::vector< long long > times;
     for (size_t iter = 0; iter < ITERATION_COUNT; iter++) {
@@ -138,8 +137,7 @@ TEST_F(TestPerformance, Time_BindColumn_FetchSingleRow) {
             ret = SQLBindCol(m_hstmt, (SQLUSMALLINT)i + 1, SQL_C_CHAR,
                              (SQLPOINTER)&cols[i][0].data_dat[i], 255,
                              &cols[i][0].data_len);
-        while (SQLFetch(m_hstmt) == SQL_SUCCESS)
-            row_count++;
+        while (SQLFetch(m_hstmt) == SQL_SUCCESS) {}
         auto end = std::chrono::steady_clock::now();
         ASSERT_TRUE(SQL_SUCCEEDED(SQLCloseCursor(m_hstmt)));
         times.push_back(
@@ -230,7 +228,6 @@ TEST_F(TestPerformance, Time_BindColumn_Fetch50Rows) {
 
 TEST_F(TestPerformance, Time_Execute_FetchSingleRow) {
     SQLSMALLINT total_columns = 0;
-    int row_count = 0;
 
     std::vector< long long > times;
     for (size_t iter = 0; iter < ITERATION_COUNT; iter++) {
@@ -250,8 +247,7 @@ TEST_F(TestPerformance, Time_Execute_FetchSingleRow) {
             ret = SQLBindCol(m_hstmt, (SQLUSMALLINT)i + 1, SQL_C_CHAR,
                              (SQLPOINTER)&cols[i][0].data_dat[i], BIND_SIZE,
                              &cols[i][0].data_len);
-        while (SQLFetch(m_hstmt) == SQL_SUCCESS)
-            row_count++;
+        while (SQLFetch(m_hstmt) == SQL_SUCCESS) {}
 
         auto end = std::chrono::steady_clock::now();
         ASSERT_TRUE(SQL_SUCCEEDED(SQLCloseCursor(m_hstmt)));

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -1,6 +1,6 @@
 {
     "name": "sql-odbc",
-    "version-string": "1.1.0.1",
+    "version-string": "1.6.0.0",
     "dependencies": [
         "aws-sdk-cpp",
         "rapidjson",
@@ -8,5 +8,5 @@
         "gtest",
         "curl"
     ],
-    "builtin-baseline": "a325228200d7f229f3337e612e0077f2a5307090"
+    "builtin-baseline": "d5ec528843d29e3a52d745a64b469f810b2cedbf"
 }


### PR DESCRIPTION
1) macOS 12 Github runner deprecated: https://github.com/actions/runner-images/issues/10721

2)
```
-- Found ZLIB: /Applications/Xcode_15.2.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib/libz.tbd (found version "1.2.12")
CMake Error at vcpkg_installed/x64-osx/share/rapidjson/RapidJSONConfig.cmake:3 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).