### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -15,14 +15,14 @@ jobs:
     steps:
       - name: GitHub App token
         id: github_app_token
-        uses: tibdex/github-app-token@v1.5.0
+        uses: tibdex/github-app-token@1901dc7d52169e70c27a8da37aef0d423e2867a2 # v1.5.0
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
           installation_id: 22958780
 
       - name: Backport
-        uses: VachaShah/backport@v1.1.4
+        uses: VachaShah/backport@28c49d91ceec57d7c9f625f1031c1a4d637251f5 # v1.1.4
         with:
           github_token: ${{ steps.github_app_token.outputs.token }}
           branch_name: backport/backport-${{ github.event.number }}

--- a/.github/workflows/bi-connectors.yml
+++ b/.github/workflows/bi-connectors.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
     - name: Prepare Power BI ODBC connector for 'OpenSearch Project'
       run: |
         cp OpenSearchProject.pq OpenSearchProject.m
@@ -37,7 +37,7 @@ jobs:
       working-directory: bi-connectors/PowerBIConnector/src
     - name: Upload Power BI ODBC connectors
       if: steps.pack-powerbi-odbc-os-proj.outcome == 'success' || (steps.prep-powerbi-odbc-amz-os-svc.outcome == 'success' && steps.pack-powerbi-odbc-amz-os-svc.outcome == 'success')
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: PBIConnectors
         path: 'bi-connectors/PowerBIConnector/src/*.mez'

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Get PR Commits
         id: 'get-pr-commits'
-        uses: tim-actions/get-pr-commits@v1.1.0
+        uses: tim-actions/get-pr-commits@55b867b9b28954e6f5c1a0fe2f729dc926c306d0 # v1.1.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: DCO Check
-        uses: tim-actions/dco@v1.1.0
+        uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # v1.1.0
         with:
           commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/delete_backport_branch.yml
+++ b/.github/workflows/delete_backport_branch.yml
@@ -10,6 +10,6 @@ jobs:
     if: startsWith(github.event.pull_request.head.ref,'backport/')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
+        uses: SvanBoxel/delete-merged-branch@2b5b058e3db41a3328fd9a6a58fd4c2545a14353 # main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release-notes-workflow.yml
+++ b/.github/workflows/draft-release-notes-workflow.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "main"
       - name: Update draft release notes
-        uses: release-drafter/release-drafter@v5
+        uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5
         with:
           config-name: draft-release-notes-config.yml
           tag: (None)

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: lychee Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@master
+        uses: lycheeverse/lychee-action@6da1d14f3a43098a294b7696d93d938aa8d20fc0 # master
         with:
           args: --accept=200,403,429  "./**/*.html" "./**/*.md" "./**/*.txt"
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -11,12 +11,12 @@ jobs:
     name: Draft a release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - id: get_data
         run: |
           echo "approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '*\n ' | sed 's/@/,/g' | sed 's/,//1')" >> $GITHUB_OUTPUT
           echo "version=$(grep DRIVER_PACKAGE_VERSION src/CMakeLists.txt | grep -o -P '\d+\.\d+\.\d+\.\d+')" >> $GITHUB_OUTPUT
-      - uses: trstringer/manual-approval@v1
+      - uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
         with:
           secret: ${{ github.TOKEN }}
           approvers: ${{ steps.get_data.outputs.approvers }}
@@ -26,7 +26,7 @@ jobs:
           exclude-workflow-initiator-as-approver: true
 
       - name: Download artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
           workflow: sql-odbc-main.yml
           commit: ${{github.sha}}
@@ -39,7 +39,7 @@ jobs:
           tar -cvf artifacts.tar.gz *-installer
 
       - name: Draft a release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           draft: true
           generate_release_notes: true

--- a/.github/workflows/sql-odbc-main.yml
+++ b/.github/workflows/sql-odbc-main.yml
@@ -21,14 +21,14 @@ jobs:
   build-mac:
     runs-on: macos-13
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Run cppcheck
       run: |
         brew install cppcheck
         sh run_cppcheck.sh
     - name: Upload cppcheck results
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: cppcheck-results
         path: cppcheck-results.log
@@ -45,7 +45,7 @@ jobs:
 
     - name: Restore vcpkg cache
       id: cache-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: src/vcpkg_installed
         key: ${{ steps.get-key.outputs.key }}
@@ -55,7 +55,7 @@ jobs:
         ./build_mac_release64.sh
 
     - name: Save vcpkg cache
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: src/vcpkg_installed
         key: ${{ steps.get-key.outputs.key }}
@@ -85,19 +85,19 @@ jobs:
     #    cp ./bin64/*.log test-output
     - name: Upload build
       if: success()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: mac64-build
         path: build-output
     - name: Upload installer
       if: success()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: mac64-installer
         path: installer
     #- name: Upload test results
     #  if: always()
-    #  uses: actions/upload-artifact@v4
+    #  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
     #  with:
     #    name: mac-test-results
     #    path: test-output
@@ -105,11 +105,11 @@ jobs:
   build-windows32:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Get specific version CMake, v3.26.3
-      uses: lukka/get-cmake@v3.26.3
+      uses: lukka/get-cmake@69b648272af7ac11ac053e77cf7a476676c38208 # v3.26.3
     - name: Add msbuild to path
-      uses: microsoft/setup-msbuild@v1.3.1
+      uses: microsoft/setup-msbuild@1ff57057b5cfdc39105cd07a01d78e9b0ea0c14c # v1.3.1
 
     - name: Get vcpkg config fingerprint
       id: get-key
@@ -118,7 +118,7 @@ jobs:
 
     - name: Restore vcpkg cache
       id: cache-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: src/vcpkg_installed
         key: ${{ steps.get-key.outputs.key }}
@@ -129,7 +129,7 @@ jobs:
 
     - name: Save vcpkg cache
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: src/vcpkg_installed
         key: ${{ steps.get-key.outputs.key }}
@@ -149,19 +149,19 @@ jobs:
         .\scripts\prepare_ci_output.ps1 $Env:ODBC_BIN_PATH $Env:ODBC_LIB_PATH $Env:ODBC_BUILD_PATH
     - name: Upload build
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: windows32-build
         path: ci-output/build
     - name: Upload installer
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: windows32-installer
         path: ci-output/installer
     #- name: Upload test results
     #  if: always()
-    #  uses: actions/upload-artifact@v4
+    #  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
     #  with:
     #    name: windows-test-results
     #    path: $CI_OUTPUT_PATH/test
@@ -169,11 +169,11 @@ jobs:
   build-windows64:
     runs-on: windows-2019
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Get specific version CMake, v3.26.3
-      uses: lukka/get-cmake@v3.26.3
+      uses: lukka/get-cmake@69b648272af7ac11ac053e77cf7a476676c38208 # v3.26.3
     - name: Add msbuild to path
-      uses: microsoft/setup-msbuild@v1.3.1
+      uses: microsoft/setup-msbuild@1ff57057b5cfdc39105cd07a01d78e9b0ea0c14c # v1.3.1
 
     - name: Get vcpkg config fingerprint
       id: get-key
@@ -182,7 +182,7 @@ jobs:
 
     - name: Restore vcpkg cache
       id: cache-restore
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: src/vcpkg_installed
         key: ${{ steps.get-key.outputs.key }}
@@ -193,7 +193,7 @@ jobs:
 
     - name: Save vcpkg cache
       if: steps.cache-restore.outputs.cache-hit != 'true'
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: src/vcpkg_installed
         key: ${{ steps.get-key.outputs.key }}
@@ -213,19 +213,19 @@ jobs:
         .\scripts\prepare_ci_output.ps1 $Env:ODBC_BIN_PATH $Env:ODBC_LIB_PATH $Env:ODBC_BUILD_PATH
     - name: Upload build
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: windows64-build
         path: ci-output/build
     - name: Upload installer
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: windows64-installer
         path: ci-output/installer
     #- name: Upload test results
     #  if: always()
-    #  uses: actions/upload-artifact@v4
+    #  uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
     #  with:
     #    name: windows-test-results
     #    path: ci-output/test-output


### PR DESCRIPTION
### Description

Pin all GitHub Action tag references to their corresponding commit SHAs.

Tags are mutable references that can be force-pushed to point to different commits, making them vulnerable to supply chain attacks. Commit SHAs are immutable and guarantee that the exact reviewed code is executed in CI workflows. This change pins all third-party actions to their current commit SHAs to prevent potential tampering.